### PR TITLE
chore: bump GitHub Actions to Node 24 compatible majors

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
           version: 9.14.4
 
@@ -36,7 +36,7 @@ jobs:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update blood donation data"

--- a/.github/workflows/import-reports.yml
+++ b/.github/workflows/import-reports.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -29,7 +29,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: import donation reports from issues"

--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # 等 Cloudflare 部署 + 快取清除完成，確保抓到的 sitemap 是新版
       - name: Wait for deployment
         run: sleep 240
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/notify-contributor.yml
+++ b/.github/workflows/notify-contributor.yml
@@ -10,9 +10,9 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'donation-report')
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 


### PR DESCRIPTION
GitHub forces Actions onto Node 24 from June 16, 2026; checkout@v4 and setup-node@v4 are deprecated. Bump checkout v4→v6, setup-node v4→v6, pnpm/action-setup v2→v6, create-pull-request v5→v8. All inputs used are unchanged across these majors; project runtime stays on Node 20.