### PR TITLE
fix: 統一站台網址來源，杜絕 localhost 烤進正式版結構化資料

### DIFF
--- a/app/2026/page.tsx
+++ b/app/2026/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import Link from "@/components/Link";
 import { ChevronRight, Gift } from "lucide-react";
+import { BASE_URL } from "@/lib/baseUrl";
 
 export const metadata: Metadata = {
   title: "2026 捐血贈品查詢 | 今年捐血有什麼贈品？",
@@ -16,19 +17,19 @@ export const metadata: Metadata = {
     "捐血活動2026",
   ],
   alternates: {
-    canonical: `${process.env.NEXT_PUBLIC_BASE_URL}/2026`,
+    canonical: `${BASE_URL}/2026`,
   },
   openGraph: {
     title: "2026 捐血贈品查詢 | 今年捐血有什麼贈品？",
     description:
       "2026 年台灣捐血贈品完整整理：電影票、超商禮券、餐飲券、生活用品、食品等。",
-    url: `${process.env.NEXT_PUBLIC_BASE_URL}/2026`,
+    url: `${BASE_URL}/2026`,
     siteName: "台灣捐血活動查詢",
     locale: "zh_TW",
     type: "website",
     images: [
       {
-        url: `${process.env.NEXT_PUBLIC_BASE_URL}/imgs/og-img.webp`,
+        url: `${BASE_URL}/imgs/og-img.webp`,
         width: 1200,
         height: 630,
         alt: "2026 捐血贈品查詢",
@@ -40,7 +41,7 @@ export const metadata: Metadata = {
     title: "2026 捐血贈品查詢 | 今年捐血有什麼贈品？",
     description:
       "2026 年台灣捐血贈品完整整理：電影票、超商禮券、餐飲券、生活用品、食品等。",
-    images: [`${process.env.NEXT_PUBLIC_BASE_URL}/imgs/og-img.webp`],
+    images: [`${BASE_URL}/imgs/og-img.webp`],
   },
 };
 
@@ -84,7 +85,7 @@ const GIFT_TYPES = [
 ];
 
 function generateJsonLd() {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
   return [
     {
       "@context": "https://schema.org",

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,8 +1,9 @@
 import { Metadata } from "next";
 import Link from "@/components/Link";
 import { ChevronRight, Heart, Mail } from "lucide-react";
+import { BASE_URL } from "@/lib/baseUrl";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = BASE_URL;
 
 export const metadata: Metadata = {
   title: "關於我們 | 台灣捐血活動查詢",

--- a/app/activity/[id]/page.tsx
+++ b/app/activity/[id]/page.tsx
@@ -16,6 +16,7 @@ import { ActivityImages } from "./ActivityImages";
 import AdCard from "@/components/AdCard";
 import OnsiteReport from "@/components/OnsiteReport";
 import { taiwanToday } from "@/lib/twDate";
+import { BASE_URL } from "@/lib/baseUrl";
 
 const AD_SLOT_ACTIVITY = process.env.NEXT_PUBLIC_ADSENSE_SLOT_CITY;
 const AD_SLOT_SIDEBAR = process.env.NEXT_PUBLIC_ADSENSE_SLOT_SIDEBAR;
@@ -94,7 +95,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { event } = await getDayData(id);
   if (!event) return { title: "找不到此活動" };
 
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
   const tagHint = event.tags?.length ? `，捐血贈品：${event.tags.join("、")}` : "";
   const title = `${event.activityDate} ${event.organization}捐血活動｜${event.location}捐血贈品查詢`;
   const description = `${event.activityDate} ${event.organization} 捐血活動，地點：${event.location}，時間：${event.time}${tagHint}。查詢附近捐血車、捐血站出車資訊。`;
@@ -167,7 +168,7 @@ export default async function ActivityPage({ params }: PageProps) {
 
   const images = event.pttData?.images || event.reportData?.images || [];
 
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
   const pageUrl = `${baseUrl}/activity/${id}`;
 
   const breadcrumbItems: Array<{ "@type": string; position: number; name: string; item: string }> = [

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,8 +1,9 @@
 import { Metadata } from "next";
 import CalendarClient from "./CalendarClient";
 import { getDonations } from "@/lib/getDonations";
+import { BASE_URL } from "@/lib/baseUrl";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = BASE_URL;
 
 export const revalidate = 86400;
 

--- a/app/city/[slug]/page.tsx
+++ b/app/city/[slug]/page.tsx
@@ -10,6 +10,7 @@ import AdCard from "@/components/AdCard";
 import GuideCallout from "@/components/GuideCallout";
 import CityGiftHighlight from "@/components/CityGiftHighlight";
 import RecentOnsiteReports from "@/components/RecentOnsiteReports";
+import { BASE_URL } from "@/lib/baseUrl";
 
 const AD_SLOT_CITY = process.env.NEXT_PUBLIC_ADSENSE_SLOT_CITY;
 
@@ -54,7 +55,7 @@ export async function generateMetadata({
     return { title: "找不到此城市" };
   }
 
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
 
   return {
     title: city.title,
@@ -110,7 +111,7 @@ function filterEventsByCity(
 }
 
 function generateJsonLd(city: CityConfig, eventCount: number) {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
 
   return [
     {

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import Link from "@/components/Link";
 import { ChevronRight, HelpCircle, ListOrdered } from "lucide-react";
 import { FAQ_DATA } from "@/data/faq";
+import { BASE_URL } from "@/lib/baseUrl";
 
 const HOW_TO_STEPS = [
   {
@@ -30,7 +31,6 @@ const HOW_TO_STEPS = [
   },
 ];
 
-
 export const metadata: Metadata = {
   title: "捐血常見問題 FAQ | 台灣捐血活動查詢",
   description:
@@ -50,18 +50,18 @@ export const metadata: Metadata = {
     "捐血需要預約嗎",
   ],
   alternates: {
-    canonical: `${process.env.NEXT_PUBLIC_BASE_URL}/faq`,
+    canonical: `${BASE_URL}/faq`,
   },
   openGraph: {
     title: "捐血常見問題 FAQ | 台灣捐血活動查詢",
     description: "捐血常見問題解答，完整捐血 FAQ 一次了解。",
-    url: `${process.env.NEXT_PUBLIC_BASE_URL}/faq`,
+    url: `${BASE_URL}/faq`,
     siteName: "台灣捐血活動查詢",
     locale: "zh_TW",
     type: "website",
     images: [
       {
-        url: `${process.env.NEXT_PUBLIC_BASE_URL}/imgs/og-img.webp`,
+        url: `${BASE_URL}/imgs/og-img.webp`,
         width: 1200,
         height: 630,
         alt: "捐血常見問題 FAQ",
@@ -71,7 +71,7 @@ export const metadata: Metadata = {
 };
 
 function generateHowToJsonLd() {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
   return {
     "@context": "https://schema.org",
     "@type": "HowTo",
@@ -93,7 +93,7 @@ function generateHowToJsonLd() {
  * Generate FAQ Schema for Google Rich Results
  */
 function generateFaqJsonLd() {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
 
   return [
     {

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,7 +1,8 @@
 import { getAllNews } from "@/lib/newsUtils";
+import { BASE_URL } from "@/lib/baseUrl";
 
 export async function GET() {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://www.bloodtw.com";
+  const baseUrl = BASE_URL;
   const articles = getAllNews().slice(0, 20);
 
   const items = articles

--- a/app/gift/[slug]/page.tsx
+++ b/app/gift/[slug]/page.tsx
@@ -8,6 +8,7 @@ import RecentOnsiteReports from "@/components/RecentOnsiteReports";
 import { GIFTS, getGiftBySlug, getAllGiftSlugs, GiftConfig } from "@/lib/giftConfig";
 import { getDonations } from "@/lib/getDonations";
 import AdCard from "@/components/AdCard";
+import { BASE_URL } from "@/lib/baseUrl";
 
 const AD_SLOT_GIFT = process.env.NEXT_PUBLIC_ADSENSE_SLOT_GIFT;
 
@@ -61,7 +62,7 @@ export async function generateMetadata({
     };
   }
 
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
 
   return {
     title: gift.title,
@@ -122,7 +123,7 @@ function filterEventsByGift(
  * Generate JSON-LD for the gift page
  */
 function generateJsonLd(gift: GiftConfig, eventCount: number) {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
 
   return [
     {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import Footer from "@/components/Footer";
 import "./globals.css";
+import { BASE_URL } from "@/lib/baseUrl";
 
 const adsenseClient = process.env.NEXT_PUBLIC_ADSENSE_CLIENT;
 
@@ -16,11 +17,7 @@ const geistMono = localFont({
   weight: "100 900",
 });
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
-
-if (!baseUrl) {
-  throw new Error("NEXT_PUBLIC_BASE_URL is not defined");
-}
+const baseUrl = BASE_URL;
 
 export const metadata: Metadata = {
   metadataBase: new URL(baseUrl),

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -6,18 +6,10 @@ import { ChevronRight } from "lucide-react";
 import { getNewsBySlug, getAllNewsSlugs, getAllNews } from "@/lib/newsUtils";
 import AdCard from "@/components/AdCard";
 import { GUIDE_SLUG } from "@/components/GuideCallout";
+import { BASE_URL, SITE_HOST } from "@/lib/baseUrl";
 
 const AD_SLOT_NEWS = process.env.NEXT_PUBLIC_ADSENSE_SLOT_NEWS;
 const AD_SLOT_SIDEBAR = process.env.NEXT_PUBLIC_ADSENSE_SLOT_SIDEBAR;
-
-// 本站網域（由 NEXT_PUBLIC_BASE_URL 推導，不寫死網址），用來判斷站內 / 站外連結
-const SITE_HOST = (() => {
-  try {
-    return new URL(process.env.NEXT_PUBLIC_BASE_URL ?? "").host.replace(/^www\./, "");
-  } catch {
-    return "";
-  }
-})();
 
 // 自動把內文中出現的網址轉成可點擊連結：站內網址走 client-side 導航，站外網址開新分頁
 function renderContent(content: string) {
@@ -71,7 +63,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   if (!article) return { title: "找不到文章" };
 
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
 
   const keywords = article.sections.map((s) => s.heading);
 
@@ -107,7 +99,7 @@ export default async function NewsArticlePage({ params }: PageProps) {
 
   if (!article) notFound();
 
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
 
   const author = article.author ?? "血荒資訊編輯部";
 

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { ChevronRight, Newspaper } from "lucide-react";
 import { getAllNews } from "@/lib/newsUtils";
 import AdCard from "@/components/AdCard";
+import { BASE_URL } from "@/lib/baseUrl";
 
 const AD_SLOT_NEWS = process.env.NEXT_PUBLIC_ADSENSE_SLOT_NEWS;
 const AD_SLOT_SIDEBAR = process.env.NEXT_PUBLIC_ADSENSE_SLOT_SIDEBAR;
@@ -14,19 +15,19 @@ export const metadata: Metadata = {
     "台灣捐血最新新聞與公告：血庫庫存動態、捐血活動特別主題、捐血政策更新等，掌握最新捐血資訊。",
   keywords: ["捐血新聞", "捐血公告", "血庫庫存", "捐血活動消息", "台灣捐血最新"],
   alternates: {
-    canonical: `${process.env.NEXT_PUBLIC_BASE_URL}/news`,
+    canonical: `${BASE_URL}/news`,
   },
   openGraph: {
     title: "捐血最新消息 | 台灣捐血活動查詢",
     description:
       "台灣捐血最新新聞與公告：血庫庫存動態、捐血活動特別主題、捐血政策更新等，掌握最新捐血資訊。",
-    url: `${process.env.NEXT_PUBLIC_BASE_URL}/news`,
+    url: `${BASE_URL}/news`,
     siteName: "台灣捐血活動查詢",
     locale: "zh_TW",
     type: "website",
     images: [
       {
-        url: `${process.env.NEXT_PUBLIC_BASE_URL}/imgs/og-img.webp`,
+        url: `${BASE_URL}/imgs/og-img.webp`,
         width: 1200,
         height: 630,
         alt: "捐血最新消息",
@@ -37,7 +38,7 @@ export const metadata: Metadata = {
 
 export default function NewsPage() {
   const articles = getAllNews();
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
 
   const breadcrumbJsonLd = {
     "@context": "https://schema.org",

--- a/app/organization/[slug]/page.tsx
+++ b/app/organization/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
   OrgConfig,
 } from "@/lib/organizationConfig";
 import { getDonations } from "@/lib/getDonations";
+import { BASE_URL } from "@/lib/baseUrl";
 
 const AD_SLOT_CITY = process.env.NEXT_PUBLIC_ADSENSE_SLOT_CITY;
 
@@ -42,7 +43,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const org = getOrgBySlug(slug);
   if (!org) return { title: "找不到此單位" };
 
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
   return {
     title: org.title,
     description: org.description,
@@ -80,7 +81,7 @@ function filterEventsByOrg(
 }
 
 function generateJsonLd(org: OrgConfig, eventCount: number) {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
   return [
     {
       "@context": "https://schema.org",

--- a/app/organization/page.tsx
+++ b/app/organization/page.tsx
@@ -2,8 +2,9 @@ import { Metadata } from "next";
 import Link from "@/components/Link";
 import { ChevronRight } from "lucide-react";
 import { ORGANIZATIONS } from "@/lib/organizationConfig";
+import { BASE_URL } from "@/lib/baseUrl";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = BASE_URL;
 
 export const metadata: Metadata = {
   title: "主辦單位捐血活動查詢｜獅子會、慈善團體、企業贊助捐血",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ import FaqSection from "@/components/FaqSection";
 import InternalLinks from "@/components/InternalLinks";
 import RecentOnsiteReports from "@/components/RecentOnsiteReports";
 import { getDonations } from "@/lib/getDonations";
+import { BASE_URL } from "@/lib/baseUrl";
 
 // 首頁完全靜態化（build 時預渲染，由 ASSETS 直接送出，worker 不在 runtime 重 render）。
 // 活動資料每天 07:40 才更新一次（GitHub Actions PR 觸發重新部署），所以不需要 runtime ISR；
@@ -108,10 +109,7 @@ export default async function BloodDonationPage() {
 
   // 生成 JSON-LD
   // 1. WebSite Schema
-  const siteUrl = process.env.NEXT_PUBLIC_BASE_URL;
-  if (!siteUrl) {
-    throw new Error("NEXT_PUBLIC_BASE_URL is not defined");
-  }
+  const siteUrl = BASE_URL;
   const websiteJsonLd = {
     "@context": "https://schema.org",
     "@type": "WebSite",

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,8 +1,9 @@
 import { Metadata } from "next";
 import Link from "@/components/Link";
 import { ChevronRight, ShieldCheck } from "lucide-react";
+import { BASE_URL } from "@/lib/baseUrl";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = BASE_URL;
 
 export const metadata: Metadata = {
   title: "隱私權政策 | 台灣捐血活動查詢",

--- a/app/recent/page.tsx
+++ b/app/recent/page.tsx
@@ -4,6 +4,7 @@ import { ChevronRight } from "lucide-react";
 import SearchableDonationList from "@/components/SearchableDonationList";
 import AddDonationEventModal from "@/components/AddDonationEventModal";
 import { getDonations } from "@/lib/getDonations";
+import { BASE_URL } from "@/lib/baseUrl";
 
 interface DonationEvent {
   id?: string;
@@ -28,7 +29,7 @@ interface DonationEvent {
   };
 }
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = BASE_URL;
 
 export const metadata: Metadata = {
   title: "近期捐血活動｜未來 7 天全台捐血行程查詢",

--- a/app/record/page.tsx
+++ b/app/record/page.tsx
@@ -1,7 +1,8 @@
 import { Metadata } from "next";
 import RecordClient from "./RecordClient";
+import { BASE_URL } from "@/lib/baseUrl";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = BASE_URL;
 
 export const metadata: Metadata = {
   title: "捐血紀錄本｜記錄每次捐血、計算下次可捐日期",

--- a/app/region/[slug]/page.tsx
+++ b/app/region/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
   RegionConfig,
 } from "@/lib/regionConfig";
 import { getDonations } from "@/lib/getDonations";
+import { BASE_URL } from "@/lib/baseUrl";
 
 interface DonationEvent {
   id?: string;
@@ -61,7 +62,7 @@ export async function generateMetadata({
     };
   }
 
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
 
   return {
     title: region.title,
@@ -121,7 +122,7 @@ function filterEventsByRegion(
  * Generate JSON-LD for the region page
  */
 function generateJsonLd(region: RegionConfig, eventCount: number) {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const baseUrl = BASE_URL;
 
   return [
     {

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,11 +1,8 @@
 import { MetadataRoute } from "next";
+import { BASE_URL } from "@/lib/baseUrl";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
-
-  if (!baseUrl) {
-    throw new Error("NEXT_PUBLIC_BASE_URL is not defined");
-  }
+  const baseUrl = BASE_URL;
 
   return {
     rules: {

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,8 +1,9 @@
 import { Metadata } from "next";
 import { Suspense } from "react";
 import SearchClient from "./SearchClient";
+import { BASE_URL } from "@/lib/baseUrl";
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = BASE_URL;
 
 export const metadata: Metadata = {
   title: "捐血活動搜尋｜全台捐血行程關鍵字查詢",

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -7,6 +7,7 @@ import { getAllCitySlugs } from "@/lib/cityConfig";
 import { getAllOrgSlugs } from "@/lib/organizationConfig";
 import { getAllNews } from "@/lib/newsUtils";
 import { eventShortId } from "@/lib/eventId";
+import { BASE_URL } from "@/lib/baseUrl";
 
 interface DonationEvent {
   id?: string;
@@ -57,10 +58,7 @@ async function getActivitySitemapEntries(
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
-  if (!baseUrl) {
-    throw new Error("NEXT_PUBLIC_BASE_URL is not defined");
-  }
+  const baseUrl = BASE_URL;
 
   const regionSlugs = getAllRegionSlugs();
   const giftSlugs = getAllGiftSlugs();

--- a/lib/baseUrl.ts
+++ b/lib/baseUrl.ts
@@ -1,0 +1,38 @@
+/**
+ * 全站對外網址的唯一真實來源（single source of truth）。
+ *
+ * canonical、Open Graph、sitemap、JSON-LD 結構化資料都需要「正式且完整的絕對網址」。
+ * 過去各檔直接讀 `process.env.NEXT_PUBLIC_BASE_URL`，但 Next.js 的 env 優先序是
+ * `.env.local` 高於 `.env.production`，所以本機 `.env.local` 的 `http://localhost:3000`
+ * 會在 `next build` 時被「悄悄」烤進正式版（build 還不會報錯，因為值不是 undefined），
+ * 導致 Google Search Console 把活動頁結構化資料的 `url` / `offers.url` / `image`
+ * 判為「網址無效」。
+ *
+ * 這裡在 production 一律以正式網域為保險，杜絕 localhost / undefined / 漏設外洩。
+ */
+const PRODUCTION_BASE_URL = "https://www.bloodtw.com";
+
+function resolveBaseUrl(): string {
+  const env = process.env.NEXT_PUBLIC_BASE_URL?.trim();
+
+  if (process.env.NODE_ENV === "production") {
+    // 正式環境：env 漏設或不小心指到 localhost，一律退回正式網域
+    if (!env || env.includes("localhost")) return PRODUCTION_BASE_URL;
+    return env.replace(/\/+$/, "");
+  }
+
+  // 開發 / 預覽：用 env，沒有就 localhost
+  return (env || "http://localhost:3000").replace(/\/+$/, "");
+}
+
+/** 完整的站台基底網址，結尾無斜線。例：`https://www.bloodtw.com` */
+export const BASE_URL = resolveBaseUrl();
+
+/** 本站網域（去掉 www.），用來判斷站內 / 站外連結。例：`bloodtw.com` */
+export const SITE_HOST = (() => {
+  try {
+    return new URL(BASE_URL).host.replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+})();


### PR DESCRIPTION
新增 lib/baseUrl.ts 作為全站對外網址的唯一來源，production 一律以
正式網域為底，避免 .env.local 的 http://localhost:3000 在 next build 時被烤進 canonical / OG / sitemap / JSON-LD（這會讓 GSC 把活動頁 結構化資料的 url / offers.url / image 判為「網址無效」）。

21 個檔案改走 BASE_URL，並清掉重複的 throw 防呆、feed.xml 的硬編
後備網址，以及 news/[slug] 自帶的 SITE_HOST。