### PR TITLE
feat: 每日自動發文到 Threads（配圖 + 活動摘要 + 連結）

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -35,6 +35,16 @@ jobs:
         env:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
 
+      # 用這次 checkout 剛爬到的 /data 內容直接組貼文，不等下面的 PR merge、
+      # 不等站台重新部署。沒設定 THREADS_* secrets 時腳本會自動跳過。
+      # continue-on-error：社群發文是錦上添花，失敗不該讓資料更新 workflow 變紅字。
+      - name: Post today's recommendation to Threads
+        continue-on-error: true
+        run: node scripts/postToThreads.js
+        env:
+          THREADS_USER_ID: ${{ secrets.THREADS_USER_ID }}
+          THREADS_ACCESS_TOKEN: ${{ secrets.THREADS_ACCESS_TOKEN }}
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:

--- a/app/api/og/news/[slug]/route.tsx
+++ b/app/api/og/news/[slug]/route.tsx
@@ -1,33 +1,8 @@
 import { ImageResponse } from "next/og";
 import { getNewsBySlug } from "@/lib/newsUtils";
+import { loadTcFont } from "@/lib/ogFont";
 
 export const runtime = "nodejs";
-
-// 動態抓 Noto Sans TC 子集（只取本圖會用到的字），讓 Satori 能渲染中文。
-// 用舊版 UA 讓 Google Fonts 回傳 TTF（Satori 不支援 woff2）；失敗則回 null 由預設拉丁字型降級。
-async function loadTcFont(text: string): Promise<ArrayBuffer | null> {
-  try {
-    const api = `https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@700&text=${encodeURIComponent(
-      text
-    )}`;
-    const cssRes = await fetch(api, {
-      headers: {
-        "User-Agent": "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)",
-      },
-    });
-    if (!cssRes.ok) return null;
-    const css = await cssRes.text();
-    const m = css.match(
-      /src:\s*url\(([^)]+)\)\s*format\(['"]?(?:truetype|opentype)['"]?\)/
-    );
-    if (!m) return null;
-    const fontRes = await fetch(m[1]);
-    if (!fontRes.ok) return null;
-    return await fontRes.arrayBuffer();
-  } catch {
-    return null;
-  }
-}
 
 const SITE = "bloodtw.com";
 const TAGLINE = "全台捐血活動・血液庫存即時查詢";

--- a/app/api/og/threads/route.tsx
+++ b/app/api/og/threads/route.tsx
@@ -1,0 +1,118 @@
+import { ImageResponse } from "next/og";
+import { getRegionBySlug } from "@/lib/regionConfig";
+import { loadTcFont } from "@/lib/ogFont";
+
+export const runtime = "nodejs";
+
+const SITE = "bloodtw.com";
+const TAGLINE = "全台捐血活動・血液庫存即時查詢";
+const HEADLINE = "今日全台捐血地點推薦";
+
+/**
+ * 給 scripts/postToThreads.js 用的每日社群貼文配圖。
+ *
+ * 刻意只吃 region + date 兩個查詢參數（不帶當日活動明細），這樣圖片內容
+ * 只取決於「哪個轄區、哪一天」，跟 /data 底下的資料檔是否已部署完全無關——
+ * 排程貼文腳本可以在剛爬完當天資料、PR 都還沒 merge 的當下就直接產文，
+ * 這張圖仍然會是對的。實際活動明細放在貼文文字內容，不放圖上。
+ */
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const regionSlug = searchParams.get("region") ?? "";
+  const date = searchParams.get("date") ?? "";
+
+  const region = getRegionBySlug(regionSlug);
+  const regionLabel = region ? `${region.displayName}` : "全台";
+
+  const font = await loadTcFont(`${HEADLINE}${SITE}${TAGLINE}${regionLabel}${date}捐血資訊`);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "1080px",
+          height: "1080px",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "80px",
+          background: "linear-gradient(135deg, #ffffff 0%, #fef2f2 100%)",
+          fontFamily: font ? "Noto Sans TC" : "sans-serif",
+        }}
+      >
+        {/* 頁首：紅色血滴點 + 站名 */}
+        <div style={{ display: "flex", alignItems: "center", gap: "16px" }}>
+          <div
+            style={{
+              width: "36px",
+              height: "36px",
+              borderRadius: "9999px",
+              background: "#ef4444",
+            }}
+          />
+          <div style={{ fontSize: "32px", fontWeight: 700, color: "#111827" }}>
+            {SITE}
+          </div>
+        </div>
+
+        {/* 主標題（左側紅色強調條） */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "28px",
+            borderLeft: "10px solid #ef4444",
+            paddingLeft: "36px",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "72px",
+              fontWeight: 700,
+              color: "#111827",
+              lineHeight: 1.3,
+              display: "flex",
+            }}
+          >
+            {HEADLINE}
+          </div>
+          <div
+            style={{
+              fontSize: "48px",
+              fontWeight: 700,
+              color: "#ef4444",
+              display: "flex",
+            }}
+          >
+            {regionLabel}
+          </div>
+        </div>
+
+        {/* 頁尾：標語 + 日期 */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            fontSize: "28px",
+            color: "#6b7280",
+          }}
+        >
+          <div style={{ display: "flex" }}>{TAGLINE}</div>
+          {date ? <div style={{ display: "flex" }}>{date}</div> : <div />}
+        </div>
+      </div>
+    ),
+    {
+      width: 1080,
+      height: 1080,
+      fonts: font
+        ? [{ name: "Noto Sans TC", data: font, weight: 700 as const, style: "normal" as const }]
+        : undefined,
+      headers: {
+        // 每張圖對應固定的 region+date，內容不會變，可以放心長快取。
+        "Cache-Control": "public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800",
+      },
+    }
+  );
+}

--- a/lib/ogFont.ts
+++ b/lib/ogFont.ts
@@ -1,0 +1,29 @@
+/**
+ * 動態抓 Noto Sans TC 子集（只取本圖會用到的字），讓 Satori 能渲染中文。
+ * 用舊版 UA 讓 Google Fonts 回傳 TTF（Satori 不支援 woff2）；失敗則回 null 由預設拉丁字型降級。
+ *
+ * 共用給 app/api/og/** 底下所有動態產圖 route 使用。
+ */
+export async function loadTcFont(text: string): Promise<ArrayBuffer | null> {
+  try {
+    const api = `https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@700&text=${encodeURIComponent(
+      text
+    )}`;
+    const cssRes = await fetch(api, {
+      headers: {
+        "User-Agent": "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)",
+      },
+    });
+    if (!cssRes.ok) return null;
+    const css = await cssRes.text();
+    const m = css.match(
+      /src:\s*url\(([^)]+)\)\s*format\(['"]?(?:truetype|opentype)['"]?\)/
+    );
+    if (!m) return null;
+    const fontRes = await fetch(m[1]);
+    if (!fontRes.ok) return null;
+    return await fontRes.arrayBuffer();
+  } catch {
+    return null;
+  }
+}

--- a/scripts/postToThreads.js
+++ b/scripts/postToThreads.js
@@ -1,0 +1,207 @@
+// scripts/postToThreads.js
+//
+// 每天早上（daily-update workflow 內，緊接在 updateData.js 之後執行）從當日剛爬到的
+// 捐血活動資料中，四個捐血中心轄區輪流挑一個，整理成一則貼文發到 Threads（@blood._.tw）。
+//
+// 設計重點：
+// - 直接讀當次 checkout 裡剛產生的 /data/bloodInfo-*.json，不等 PR merge、不等站台重新部署，
+//   所以貼文文字內容永遠是「今天早上剛爬到的最新資料」。
+// - 配圖走 app/api/og/threads route，只帶 region + date 兩個參數，跟資料檔部署時機無關
+//   （見該 route 檔案開頭註解）。
+// - 沒設定 THREADS_USER_ID / THREADS_ACCESS_TOKEN 時直接跳過並印出原因，不讓整個
+//   daily-update workflow 因為社群發文失敗而變紅字。
+//
+// 手動測試：node scripts/postToThreads.js
+// 需要環境變數：THREADS_USER_ID、THREADS_ACCESS_TOKEN，選填 NEXT_PUBLIC_BASE_URL（預設正式站）
+
+import { promises as fs } from "fs";
+import path from "path";
+
+const BASE_URL = (process.env.NEXT_PUBLIC_BASE_URL || "https://www.bloodtw.com").replace(/\/+$/, "");
+const THREADS_USER_ID = process.env.THREADS_USER_ID;
+const THREADS_ACCESS_TOKEN = process.env.THREADS_ACCESS_TOKEN;
+const GRAPH_BASE = "https://graph.threads.net/v1.0";
+
+// 對應 lib/regionConfig.ts 的四個轄區（捐血中心 = data 裡 event.center 的值）。
+const REGIONS = [
+  { slug: "north", displayName: "北區", centerFilter: "台北", areaNote: "台北、新北、基隆、宜蘭、花蓮" },
+  { slug: "hsinchu", displayName: "桃竹苗", centerFilter: "新竹", areaNote: "桃園、新竹、苗栗" },
+  { slug: "central", displayName: "中區", centerFilter: "台中", areaNote: "台中、彰化、南投" },
+  { slug: "south", displayName: "南區", centerFilter: "高雄", areaNote: "高雄、台南、嘉義、屏東" },
+];
+
+const WEEKDAY_LABELS = ["日", "一", "二", "三", "四", "五", "六"];
+
+/** 取得台灣時區（UTC+8，無日光節約）的今天日期字串與相關欄位。 */
+function getTaipeiToday() {
+  const now = new Date(Date.now() + 8 * 60 * 60 * 1000); // 用 UTC+8 位移取得台灣當地時間欄位
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth() + 1;
+  const day = now.getUTCDate();
+  const dateStr = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+  const weekday = WEEKDAY_LABELS[now.getUTCDay()];
+
+  const startOfYear = Date.UTC(year, 0, 1);
+  const dayOfYear = Math.floor((Date.UTC(year, month - 1, day) - startOfYear) / 86400000) + 1;
+
+  return { year, month, dateStr, weekday, dayOfYear };
+}
+
+async function loadTodayEvents(year, month, dateStr) {
+  const file = path.join(process.cwd(), "data", `bloodInfo-${year}${String(month).padStart(2, "0")}.json`);
+  let raw;
+  try {
+    raw = await fs.readFile(file, "utf-8");
+  } catch {
+    return [];
+  }
+  const monthData = JSON.parse(raw);
+  return monthData[dateStr] || [];
+}
+
+/** 從 dayOfYear 決定輪替起始的轄區，往後找第一個「今天有活動」的轄區。 */
+function pickRegion(events, dayOfYear) {
+  const startIndex = dayOfYear % REGIONS.length;
+  for (let i = 0; i < REGIONS.length; i++) {
+    const region = REGIONS[(startIndex + i) % REGIONS.length];
+    const regionEvents = events.filter((e) => e.center === region.centerFilter);
+    if (regionEvents.length > 0) {
+      return { region, regionEvents };
+    }
+  }
+  return null;
+}
+
+/** 從轄區當日活動中挑幾筆不重複地點、依時間排序的代表活動。 */
+function pickHighlights(regionEvents, max = 4) {
+  const seen = new Set();
+  const sorted = [...regionEvents].sort((a, b) => (a.time || "").localeCompare(b.time || ""));
+  const highlights = [];
+  for (const e of sorted) {
+    const key = `${e.organization}|${e.location}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    highlights.push(e);
+    if (highlights.length >= max) break;
+  }
+  return highlights;
+}
+
+function buildCaption({ region, regionEvents, highlights, dateStr, weekday }) {
+  const lines = [];
+  lines.push(`今日全台捐血地點推薦｜${dateStr}（週${weekday}）`);
+  lines.push("");
+  lines.push(`${region.displayName}（${region.areaNote}）今天共有 ${regionEvents.length} 場捐血活動，例如：`);
+  lines.push("");
+  for (const e of highlights) {
+    const location = (e.location || "").slice(0, 40);
+    lines.push(`・${e.time}　${e.organization}｜${location}`);
+  }
+  lines.push("");
+  lines.push("完整地點、開放時間、即時庫存查詢：");
+  lines.push(`${BASE_URL}/region/${region.slug}`);
+  lines.push("");
+  lines.push("#捐血 #台灣捐血 #愛心捐血");
+
+  // Threads 貼文文字上限約 500 字，超過就砍掉多餘的活動明細行再重組一次。
+  let caption = lines.join("\n");
+  if (caption.length > 480 && highlights.length > 1) {
+    return buildCaption({
+      region,
+      regionEvents,
+      highlights: highlights.slice(0, highlights.length - 1),
+      dateStr,
+      weekday,
+    });
+  }
+  return caption;
+}
+
+async function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** 建立媒體容器，輪詢到 FINISHED 再回傳 containerId。 */
+async function createAndWaitContainer({ text, imageUrl }) {
+  const createUrl = new URL(`${GRAPH_BASE}/${THREADS_USER_ID}/threads`);
+  createUrl.searchParams.set("media_type", "IMAGE");
+  createUrl.searchParams.set("image_url", imageUrl);
+  createUrl.searchParams.set("text", text);
+  createUrl.searchParams.set("access_token", THREADS_ACCESS_TOKEN);
+
+  const createRes = await fetch(createUrl, { method: "POST" });
+  const createBody = await createRes.json();
+  if (!createRes.ok || !createBody.id) {
+    throw new Error(`建立 Threads 媒體容器失敗：${JSON.stringify(createBody)}`);
+  }
+  const containerId = createBody.id;
+
+  // Meta 建議發布前先輪詢容器狀態，圖片通常幾秒內就會是 FINISHED。
+  const statusUrl = new URL(`${GRAPH_BASE}/${containerId}`);
+  statusUrl.searchParams.set("fields", "status,error_message");
+  statusUrl.searchParams.set("access_token", THREADS_ACCESS_TOKEN);
+
+  for (let attempt = 0; attempt < 10; attempt++) {
+    await sleep(3000);
+    const statusRes = await fetch(statusUrl);
+    const statusBody = await statusRes.json();
+    if (statusBody.status === "FINISHED") {
+      return containerId;
+    }
+    if (statusBody.status === "ERROR") {
+      throw new Error(`Threads 媒體容器處理失敗：${statusBody.error_message || JSON.stringify(statusBody)}`);
+    }
+  }
+  throw new Error("Threads 媒體容器逾時未完成處理（等了 30 秒）");
+}
+
+async function publishContainer(containerId) {
+  const publishUrl = new URL(`${GRAPH_BASE}/${THREADS_USER_ID}/threads_publish`);
+  publishUrl.searchParams.set("creation_id", containerId);
+  publishUrl.searchParams.set("access_token", THREADS_ACCESS_TOKEN);
+
+  const publishRes = await fetch(publishUrl, { method: "POST" });
+  const publishBody = await publishRes.json();
+  if (!publishRes.ok || !publishBody.id) {
+    throw new Error(`發布 Threads 貼文失敗：${JSON.stringify(publishBody)}`);
+  }
+  return publishBody.id;
+}
+
+async function main() {
+  if (!THREADS_USER_ID || !THREADS_ACCESS_TOKEN) {
+    console.log("[postToThreads] 尚未設定 THREADS_USER_ID / THREADS_ACCESS_TOKEN，略過本次發文。");
+    return;
+  }
+
+  const { year, month, dateStr, weekday, dayOfYear } = getTaipeiToday();
+  const events = await loadTodayEvents(year, month, dateStr);
+  if (events.length === 0) {
+    console.log(`[postToThreads] ${dateStr} 沒有任何捐血活動資料，略過本次發文。`);
+    return;
+  }
+
+  const picked = pickRegion(events, dayOfYear);
+  if (!picked) {
+    console.log(`[postToThreads] ${dateStr} 四個轄區都沒有活動資料，略過本次發文。`);
+    return;
+  }
+  const { region, regionEvents } = picked;
+  const highlights = pickHighlights(regionEvents);
+
+  const caption = buildCaption({ region, regionEvents, highlights, dateStr, weekday });
+  const imageUrl = `${BASE_URL}/api/og/threads?region=${region.slug}&date=${dateStr}`;
+
+  console.log(`[postToThreads] 今天推薦轄區：${region.displayName}（共 ${regionEvents.length} 場活動）`);
+  console.log(`[postToThreads] 貼文內容預覽：\n${caption}`);
+  console.log(`[postToThreads] 配圖網址：${imageUrl}`);
+
+  const containerId = await createAndWaitContainer({ text: caption, imageUrl });
+  const postId = await publishContainer(containerId);
+  console.log(`[postToThreads] 發布成功，Threads 貼文 id：${postId}`);
+}
+
+main().catch((err) => {
+  console.error("[postToThreads] 發文失敗：", err);
+  process.exitCode = 1;
+});

--- a/scripts/refreshThreadsToken.js
+++ b/scripts/refreshThreadsToken.js
@@ -1,0 +1,32 @@
+// scripts/refreshThreadsToken.js
+//
+// Threads 的 long-lived access token 效期 60 天，需要在過期前手動換發新的，
+// 否則 postToThreads.js 會開始失敗。建議每 50 天左右手動跑一次：
+//
+//   THREADS_ACCESS_TOKEN=舊的token node scripts/refreshThreadsToken.js
+//
+// 換到新 token 後，記得回 GitHub repo → Settings → Secrets → Actions
+// 把 THREADS_ACCESS_TOKEN 更新成新的值（GitHub Actions 沒辦法自己改自己的 secret）。
+
+const token = process.env.THREADS_ACCESS_TOKEN;
+
+if (!token) {
+  console.error("請帶入 THREADS_ACCESS_TOKEN 環境變數（目前正在使用、尚未過期的 token）。");
+  process.exit(1);
+}
+
+const url = new URL("https://graph.threads.net/refresh_access_token");
+url.searchParams.set("grant_type", "th_refresh_token");
+url.searchParams.set("access_token", token);
+
+const res = await fetch(url);
+const body = await res.json();
+
+if (!res.ok || !body.access_token) {
+  console.error("換發失敗：", JSON.stringify(body, null, 2));
+  process.exit(1);
+}
+
+console.log("換發成功，新的 long-lived token（效期約 60 天）：\n");
+console.log(body.access_token);
+console.log("\n請把它更新到 GitHub repo 的 THREADS_ACCESS_TOKEN secret。");


### PR DESCRIPTION
在既有 daily-update workflow 內、updateData 之後新增一步，讀當次剛爬到的 /data 內容，四個捐血中心轄區輪流挑一個有活動的，組成一則貼文發到 Threads。

- scripts/postToThreads.js：整理當日活動、輪替轄區、呼叫 Threads Graph API （建立媒體容器→輪詢→發布）。缺 THREADS_* 金鑰時自動跳過，不讓 workflow 變紅字。
- app/api/og/threads：1080x1080 社群配圖，只吃 region+date，與資料檔部署時機無關。
- lib/ogFont.ts：抽出 OG 圖共用的 Noto Sans TC 子集載入，news OG route 一起改用。
- scripts/refreshThreadsToken.js：長期 token（60 天）到期前手動換發用。
- workflow 那步 continue-on-error，社群發文失敗不影響資料更新。